### PR TITLE
adds python 3.7 compatibility

### DIFF
--- a/octoprint_filamentmanager/__init__.py
+++ b/octoprint_filamentmanager/__init__.py
@@ -357,7 +357,7 @@ class FilamentManagerPlugin(FilamentManagerApi,
 
 
 __plugin_name__ = "Filament Manager"
-
+__plugin_pythoncompat__ = ">=2.7,<4"
 __required_octoprint_version__ = ">=1.3.6"
 
 

--- a/octoprint_filamentmanager/__init__.py
+++ b/octoprint_filamentmanager/__init__.py
@@ -257,7 +257,7 @@ class FilamentManagerPlugin(FilamentManagerApi,
             volume = (length * PI * radius * radius) / 1000  # cm³
             return volume * profile["density"]  # g
 
-        for tool in xrange(0, numTools):
+        for tool in range(0, numTools):
             self._logger.info("Filament used: {length} mm (tool{id})"
                               .format(length=str(extrusion[tool]), id=str(tool)))
 

--- a/octoprint_filamentmanager/api/util.py
+++ b/octoprint_filamentmanager/api/util.py
@@ -17,4 +17,4 @@ def add_revalidation_header_with_no_max_age(response, lm, etag):
 
 
 def entity_tag(lm):
-    return (hashlib.sha1(str(lm).encode(encoding='UTF-8')).hexdigest()
+    return (hashlib.sha1(str(lm).encode(encoding='UTF-8')).hexdigest())

--- a/octoprint_filamentmanager/api/util.py
+++ b/octoprint_filamentmanager/api/util.py
@@ -17,4 +17,4 @@ def add_revalidation_header_with_no_max_age(response, lm, etag):
 
 
 def entity_tag(lm):
-    return (hashlib.sha1(str(lm))).hexdigest()
+    return (hashlib.sha1(str(lm).encode(encoding='UTF-8')).hexdigest()


### PR DESCRIPTION
I upgraded to Python 3.7 and I could not run your plug-in.

I got the following error: "Plugin Filament Manager (0.5.3) is not compatible to Python 3.7.3 (compatibility string: >=2.7,<3)."

So I just added the __plugin_pythoncompat__ information and run this plugin. I just needed to add the UTF-8 encoding within your entity_tag function. Now it works like a charm with Python 3.7.3 and I had no issue with my OctoPrint setup.
